### PR TITLE
feat: profile page and profile delete

### DIFF
--- a/frontend/app/(dashboard)/profile/page.tsx
+++ b/frontend/app/(dashboard)/profile/page.tsx
@@ -1,15 +1,35 @@
 'use client';
 
-import { Avatar, Button, Card, HStack, Stack, Tag, TagLabel, TagLeftIcon, VStack } from "@chakra-ui/react";
+import { useState } from "react";
+import { 
+  Avatar, 
+  Button, 
+  Card, 
+  HStack, 
+  Popover, 
+  PopoverBody,
+  PopoverContent,
+  PopoverCloseButton, 
+  PopoverTrigger, 
+  Stack, Tag, TagLabel, TagLeftIcon, VStack } from "@chakra-ui/react";
 import { AtSignIcon, LinkIcon } from "@chakra-ui/icons";
+import { deleteUser } from "@/services/userService";
 import useAuth from "@/hooks/useAuth";
 
+
 export default function ProfilePage() {
-  const { username, email } = useAuth();
+  const { userId, username, email } = useAuth();
+  // TODO:
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+
+  const handleDeleteProfile = () => {
+    deleteUser(userId);
+  }
+
   return (
     <div className="p-8">
       <Stack spacing={20} direction={'row'}>
-      <Card width='350px' height='250px' marginLeft='10px'>
+      <Card width='350px' height='320px' marginLeft='10px'>
         <HStack>
           <Avatar size='2xl' name='Dan Abrahmov' src='https://cdn-icons-png.flaticon.com/128/17446/17446833.png' margin='30px'/>
           <VStack align='left'>
@@ -23,10 +43,20 @@ export default function ProfilePage() {
             </Tag>
           </VStack>
         </HStack>
-        <Button backgroundColor='#38A169' color='#FFFFFF' margin='10px' onClick={()=>{}}>Edit Profile</Button>
+        <Button backgroundColor='#38A169' color='#FFFFFF' margin='10px' onClick={()=> setIsEdit(true)}>Edit Profile</Button>
+        <Popover>
+          <PopoverTrigger>
+            <Button backgroundColor='#E53E3E' color='#FFFFFF' margin='10px'>Delete Profile</Button>
+          </PopoverTrigger>
+          <PopoverContent alignContent={'space'}>
+            <PopoverCloseButton />
+            <PopoverBody>Are you sure you want to delete your account?</PopoverBody>
+            <Button colorScheme='blue' width='50%' alignSelf='center' margin='5px'onClick={handleDeleteProfile}>Confirm</Button>
+          </PopoverContent>
+        </Popover>
       </Card>
       <Card width='800px' height='395px'>
-        Display Content? For delete and edit content
+        Display Content... Mb for Recent Activities (questions attempted)
       </Card>
       </Stack>
     </div>

--- a/frontend/app/(dashboard)/profile/page.tsx
+++ b/frontend/app/(dashboard)/profile/page.tsx
@@ -1,7 +1,34 @@
+'use client';
+
+import { Avatar, Button, Card, HStack, Stack, Tag, TagLabel, TagLeftIcon, VStack } from "@chakra-ui/react";
+import { AtSignIcon, LinkIcon } from "@chakra-ui/icons";
+import useAuth from "@/hooks/useAuth";
+
 export default function ProfilePage() {
+  const { username, email } = useAuth();
   return (
     <div className="p-8">
-      Profile Page
+      <Stack spacing={20} direction={'row'}>
+      <Card width='350px' height='250px' marginLeft='10px'>
+        <HStack>
+          <Avatar size='2xl' name='Dan Abrahmov' src='https://cdn-icons-png.flaticon.com/128/17446/17446833.png' margin='30px'/>
+          <VStack align='left'>
+            <Tag size='sm' key='sm' variant='subtle' colorScheme='cyan'>
+              <TagLeftIcon boxSize='12px' as={AtSignIcon} />
+              <TagLabel>{username}</TagLabel>
+            </Tag>
+            <Tag size='sm' key='sm' variant='subtle' colorScheme='cyan'>
+              <TagLeftIcon boxSize='12px' as={LinkIcon} />
+              <TagLabel>{email}</TagLabel>
+            </Tag>
+          </VStack>
+        </HStack>
+        <Button backgroundColor='#38A169' color='#FFFFFF' margin='10px' onClick={()=>{}}>Edit Profile</Button>
+      </Card>
+      <Card width='800px' height='395px'>
+        Display Content? For delete and edit content
+      </Card>
+      </Stack>
     </div>
   );
 }

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import { verifyToken } from '@/services/userService';
 
 const useAuth = () => {
 	const router = useRouter();
+	const [userId, setUserId] = useState("");
 	const [username, setUsername] = useState("");
 	const [email, setEmail] = useState("");
 	const [isAdmin, setIsAdmin] = useState(false);
@@ -13,7 +14,8 @@ const useAuth = () => {
 		const checkToken = async () => {
 			try {
 				const response = await verifyToken();
-				const { username, email, isAdmin } = response.data;
+				const { id, username, email, isAdmin } = response.data;
+				setUserId(id);
 				setUsername(username);
 				setEmail(email);
 				setIsAdmin(isAdmin);
@@ -27,7 +29,7 @@ const useAuth = () => {
 		checkToken();
 	}, [router]);
 
-	return { username, email, isAdmin, isLoading };
+	return { userId, username, email, isAdmin, isLoading };
 };
 
 export default useAuth;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.2.2",
         "@chakra-ui/next-js": "^2.2.0",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.13.3",
@@ -579,6 +580,16 @@
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.2.2.tgz",
+      "integrity": "sha512-qmQHmc9hoGaGLpSiYeKFyC9zmCFvBdOs2vkHomlXSPsDqLDZYpADFYgSeqodcYmTZhywI5Ax/EIlGEz0jdAiyA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/react": ">=2.0.0",
         "react": ">=18"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.2.2",
     "@chakra-ui/next-js": "^2.2.0",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.13.3",

--- a/frontend/services/userService.ts
+++ b/frontend/services/userService.ts
@@ -20,6 +20,11 @@ export const loginUser = async (email: string, password: string) => {
   }
 };
 
+export const logout = async () => {
+  localStorage.removeItem('authToken');
+  window.location.reload();
+}
+
 export const verifyToken = async () => {
   const accessToken = localStorage.getItem('authToken');
   if (!accessToken) {
@@ -36,5 +41,26 @@ export const verifyToken = async () => {
   } catch (error) {
     console.error('Error verifying token:', error);
     throw error;
+  }
+}
+
+export const deleteUser = async (userId: string) => {
+  const accessToken = localStorage.getItem('authToken');
+  if (!accessToken) {
+    return false;
+  }
+  try {
+    const response = await axios.delete(`http://localhost:8003/users/${userId}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    console.log(`User ${userId} deleted`);
+    return response.data;
+  } catch (error) {
+    console.error('Error verifying token:', error);
+    throw error;
+  } finally {
+    await logout();
   }
 }


### PR DESCRIPTION
# Note
This is branched off Eric's current [PR](https://github.com/CS3219-AY2425S1/cs3219-ay2425s1-project-g07/pull/25) (because of some function he wrote that can be reused)

# Changes
Profile page [skeleton]
![image](https://github.com/user-attachments/assets/555b00d8-a7ad-45a4-9630-2378ee3b0c06)

Delete profile confirmation
![image](https://github.com/user-attachments/assets/9506d942-1cf5-4ea5-9d89-acff5f4512be)

It will logout after "confirming"


Please let me know if there are anywhere that can be better written

# TODO:
- Edit profile functionality