### PR TITLE
update question CRUD based on admin role

### DIFF
--- a/backend/question-service/src/dto/question.dto.ts
+++ b/backend/question-service/src/dto/question.dto.ts
@@ -34,6 +34,11 @@ export class CreateQuestionDto {
     @IsString()
     @IsNotEmpty()
     readonly link: string;
+
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    readonly solution: string;
 }
 
 export class UpdateQuestionDto extends PartialType(CreateQuestionDto) { }

--- a/backend/question-service/src/schemas/question.schema.ts
+++ b/backend/question-service/src/schemas/question.schema.ts
@@ -52,6 +52,8 @@ export class Question {
     @Prop({ required: true })
     link: string;
 
+    @Prop({ required: true })
+    solution: string;
 }
 
 export const QuestionSchema = SchemaFactory.createForClass(Question);

--- a/frontend/app/(dashboard)/questions/create/page.tsx
+++ b/frontend/app/(dashboard)/questions/create/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { Box, Button, FormControl, FormLabel, Input, Select, Flex, Textarea, useToast } from "@chakra-ui/react";
+import { Box, Button, FormControl, FormLabel, Input, Select, Flex, Textarea, useToast, Spinner } from "@chakra-ui/react";
 import { useState } from "react";
 import { Question, QuestionComplexity, QuestionTopic } from "@/types/Question";
 import { createQuestion } from "@/services/questionService";
 import { marked } from 'marked';
 import { topicText } from '@/app/utils';
 import { useRouter } from 'next/navigation';
+import useAuth from "@/hooks/useAuth";
 
 export default function CreateQuestionPage() {
+  const { isAdmin, isLoading } = useAuth();
   const router = useRouter();
   const toast = useToast();
 
@@ -73,6 +75,11 @@ export default function CreateQuestionPage() {
       }
     }
   };
+
+  // Prevent non-admin users from accessing the page
+  if (!isLoading && !isAdmin) {
+    router.push('/questions');
+  }
 
   return (
     <Box p={8} h="100%">
@@ -142,14 +149,16 @@ export default function CreateQuestionPage() {
         <Input name="link" value={link} onChange={handleLinkChange} />
       </FormControl>
 
-      <Flex alignItems="center" gap={4}>
-        <Button colorScheme="teal" onClick={handleSubmit}>
-          Create
-        </Button>
-        <Button colorScheme="red" onClick={() => router.push('/questions')}>
-          Cancel
-        </Button>
-      </Flex>
+      {isAdmin && (
+        <Flex alignItems="center" gap={4}>
+          <Button colorScheme="teal" onClick={handleSubmit}>
+            Create
+          </Button>
+          <Button colorScheme="red" onClick={() => router.push('/questions')}>
+            Cancel
+          </Button>
+        </Flex>
+      )}
     </Box>
   );
 }

--- a/frontend/app/(dashboard)/questions/create/page.tsx
+++ b/frontend/app/(dashboard)/questions/create/page.tsx
@@ -8,6 +8,7 @@ import { marked } from 'marked';
 import { topicText } from '@/app/utils';
 import { useRouter } from 'next/navigation';
 import useAuth from "@/hooks/useAuth";
+import Editor from '@monaco-editor/react';
 
 export default function CreateQuestionPage() {
   const { isAdmin, isLoading } = useAuth();
@@ -19,6 +20,7 @@ export default function CreateQuestionPage() {
   const [topics, setTopics] = useState<Set<QuestionTopic>>(new Set());
   const [complexity, setComplexity] = useState<QuestionComplexity | undefined>();
   const [link, setLink] = useState("");
+  const [solution, setSolution] = useState("def main():\n\tprint(\"Hello, World!\")");
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value);
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => setDescription(e.target.value);
@@ -30,7 +32,7 @@ export default function CreateQuestionPage() {
   const handleLinkChange = (e: React.ChangeEvent<HTMLInputElement>) => setLink(e.target.value);
 
   const handleSubmit = async () => {
-    if (!title || !description || topics.size === 0 || !complexity || !link) {
+    if (!title || !description || topics.size === 0 || !complexity || !link || !solution) {
       toast.closeAll();
       toast({
         title: "All fields are required.",
@@ -48,6 +50,7 @@ export default function CreateQuestionPage() {
       topics: Array.from(topics),
       complexity,
       link,
+      solution,
     };
 
     try {
@@ -149,8 +152,25 @@ export default function CreateQuestionPage() {
         <Input name="link" value={link} onChange={handleLinkChange} />
       </FormControl>
 
+      <FormControl id="solution" mb={4} isRequired>
+        <FormLabel>Solution (Python)</FormLabel>
+        <Box height="400px" border="1px" borderColor="gray.200" borderRadius="md">
+          <Editor
+            height="100%"
+            value={solution}
+            onChange={(value) => setSolution(value || "")}
+            theme='vs-dark'
+            defaultLanguage="python"
+            options={{
+              minimap: { enabled: false },
+              automaticLayout: true
+            }}
+          />
+        </Box>
+      </FormControl>
+
       {isAdmin && (
-        <Flex alignItems="center" gap={4}>
+        <Flex alignItems="center" gap={4} pb={4}>
           <Button colorScheme="teal" onClick={handleSubmit}>
             Create
           </Button>

--- a/frontend/app/(dashboard)/questions/page.tsx
+++ b/frontend/app/(dashboard)/questions/page.tsx
@@ -11,9 +11,11 @@ import { EditIcon } from '@/public/icons/EditIcon';
 import { useRouter } from 'next/navigation';
 import { AxiosError } from 'axios';
 import { difficultyText, topicText } from '../../utils';
+import useAuth from '@/hooks/useAuth';
 
 export default function QuestionsPage() {
   const router = useRouter();
+  const { isAdmin } = useAuth();
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<AxiosError | null>(null);
@@ -72,47 +74,51 @@ export default function QuestionsPage() {
                   <Th width="50%">Title</Th>
                   <Th width="10%">Difficulty</Th>
                   <Th width="30%">Topics</Th>
-                  <Th width="10%">Actions</Th>
+                  {isAdmin && <Th width="10%">Actions</Th>}
                 </Tr>
               </Thead>
               <Tbody>
                 {questionData && questionData.length > 0 ? (questionData.map((question, index) => (
                   <Tr key={index}>
-                  <Td><QuestionModal {...question} /></Td>
-                  <Td>{difficultyText(question.complexity)}</Td>
-                  <Td>
-                    {question.topics.map((topic, idx) => (
-                    topicText(topic, idx)
-                    ))}
-                  </Td>
-                  <Td sx={{ py: 3 }}>
-                    <IconButton
-                      aria-label="Delete question"
-                      icon={<TrashIcon />}
-                      onClick={() => question._id && openAlert(question._id)}
-                      variant="ghost"
-                      _hover={{ bg: 'lightblue' }}
-                    />
-                    <IconButton
-                      aria-label="Edit question"
-                      icon={<EditIcon />}
-                      variant="ghost"
-                      onClick={() => router.push(`./questions/update/${question._id}`)}
-                      _hover={{ bg: 'lightblue' }}
-                    />
-                  </Td>
+                    <Td><QuestionModal {...question} /></Td>
+                    <Td>{difficultyText(question.complexity)}</Td>
+                    <Td>
+                      {question.topics.map((topic, idx) => (
+                        topicText(topic, idx)
+                      ))}
+                    </Td>
+                    {isAdmin && (
+                      <Td sx={{ py: 3 }}>
+                        <IconButton
+                          aria-label="Delete question"
+                          icon={<TrashIcon />}
+                          onClick={() => question._id && openAlert(question._id)}
+                          variant="ghost"
+                          _hover={{ bg: 'lightblue' }}
+                        />
+                        <IconButton
+                          aria-label="Edit question"
+                          icon={<EditIcon />}
+                          variant="ghost"
+                          onClick={() => router.push(`./questions/update/${question._id}`)}
+                          _hover={{ bg: 'lightblue' }}
+                        />
+                      </Td>
+                    )}
                   </Tr>
                 ))) : (
                   <Tr>
-                  <Td colSpan={4} className='text-center'>No questions found.</Td>
+                    <Td colSpan={4} className='text-center'>No questions found.</Td>
                   </Tr>
                 )}
               </Tbody>
             </Table>
           </TableContainer>
-          <Button colorScheme="teal" className='mt-4 mb-4' onClick={() => router.push('/questions/create')}>
-            Add New Question
-          </Button>
+          {isAdmin && (
+            <Button colorScheme="teal" className='mt-4 mb-4' onClick={() => router.push('/questions/create')}>
+              Add New Question
+            </Button>
+          )}
         </>
       )}
 

--- a/frontend/app/(dashboard)/questions/update/[id]/page.tsx
+++ b/frontend/app/(dashboard)/questions/update/[id]/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, Button, FormControl, FormLabel, Input, Select, Textarea, Flex, useToast } from "@chakra-ui/react";
+import { Box, Button, FormControl, FormLabel, Input, Select, Textarea, Flex, useToast, Spinner } from "@chakra-ui/react";
 import { getQuestionById, updateQuestion } from "@/services/questionService";
 import { Question, QuestionComplexity, QuestionTopic } from "@/types/Question";
 import { marked } from "marked";
 import { topicText } from "@/app/utils";
 import { useRouter } from 'next/navigation';
+import useAuth from "@/hooks/useAuth";
 
 export default function Page({ params }: { params: { id: string } }) {
+  const { isAdmin, isLoading } = useAuth();
   const id = params.id;
   const router = useRouter();
   const toast = useToast();
@@ -90,6 +92,11 @@ export default function Page({ params }: { params: { id: string } }) {
     }
   };
 
+  // Prevent non-admin users from accessing the page
+  if (!isLoading && !isAdmin) {
+    router.push('/questions');
+  }
+
   return (
     <Box p={8} h="100%">
       <FormControl id="title" mb={4} isRequired>
@@ -158,14 +165,16 @@ export default function Page({ params }: { params: { id: string } }) {
         <Input name="link" value={link} onChange={handleLinkChange} />
       </FormControl>
 
-      <Flex alignItems="center" gap={4}>
-        <Button colorScheme="teal" onClick={handleSubmit}>
-          Update
-        </Button>
-        <Button colorScheme="red" onClick={() => router.push('/questions')}>
-          Cancel
-        </Button>
-      </Flex>
+      {isAdmin && (
+        <Flex alignItems="center" gap={4}>
+          <Button colorScheme="teal" onClick={handleSubmit}>
+            Update
+          </Button>
+          <Button colorScheme="red" onClick={() => router.push('/questions')}>
+            Cancel
+          </Button>
+        </Flex>
+      )}
     </Box>
   );
 }

--- a/frontend/app/(dashboard)/questions/update/[id]/page.tsx
+++ b/frontend/app/(dashboard)/questions/update/[id]/page.tsx
@@ -8,6 +8,7 @@ import { marked } from "marked";
 import { topicText } from "@/app/utils";
 import { useRouter } from 'next/navigation';
 import useAuth from "@/hooks/useAuth";
+import Editor from '@monaco-editor/react';
 
 export default function Page({ params }: { params: { id: string } }) {
   const { isAdmin, isLoading } = useAuth();
@@ -20,6 +21,7 @@ export default function Page({ params }: { params: { id: string } }) {
   const [topics, setTopics] = useState<Set<QuestionTopic>>(new Set());
   const [complexity, setComplexity] = useState<QuestionComplexity | "">("");
   const [link, setLink] = useState("");
+  const [solution, setSolution] = useState("");
 
   useEffect(() => {
     async function fetchQuestion() {
@@ -30,6 +32,7 @@ export default function Page({ params }: { params: { id: string } }) {
         setTopics(new Set(question.topics));
         setComplexity(question.complexity);
         setLink(question.link);
+        setSolution(question.solution);
       }
     }
 
@@ -46,7 +49,7 @@ export default function Page({ params }: { params: { id: string } }) {
   const handleLinkChange = (e: React.ChangeEvent<HTMLInputElement>) => setLink(e.target.value);
 
   const handleSubmit = async () => {
-    if (!title || !description || topics.size === 0 || !complexity || !link) {
+    if (!title || !description || topics.size === 0 || !complexity || !link || !solution) {
       toast.closeAll();
       toast({
         title: "All fields are required.",
@@ -64,6 +67,7 @@ export default function Page({ params }: { params: { id: string } }) {
       topics: Array.from(topics),
       complexity: complexity as QuestionComplexity,
       link,
+      solution,
     };
 
     try {
@@ -165,8 +169,25 @@ export default function Page({ params }: { params: { id: string } }) {
         <Input name="link" value={link} onChange={handleLinkChange} />
       </FormControl>
 
+      <FormControl id="solution" mb={4} isRequired>
+        <FormLabel>Solution (Python)</FormLabel>
+        <Box height="400px" border="1px" borderColor="gray.200" borderRadius="md">
+          <Editor
+            height="100%"
+            value={solution}
+            onChange={(value) => setSolution(value || "")}
+            theme='vs-dark'
+            defaultLanguage="python"
+            options={{
+              minimap: { enabled: false },
+              automaticLayout: true
+            }}
+          />
+        </Box>
+      </FormControl>
+
       {isAdmin && (
-        <Flex alignItems="center" gap={4}>
+        <Flex alignItems="center" gap={4} pb={4}>
           <Button colorScheme="teal" onClick={handleSubmit}>
             Update
           </Button>

--- a/frontend/app/(dashboard)/rooms/[roomId]/page.tsx
+++ b/frontend/app/(dashboard)/rooms/[roomId]/page.tsx
@@ -20,7 +20,6 @@ export default function Page({ params }: PageParams) {
   const [room, setRoom] = useState<Room>();
   const [loading, setLoading] = useState(true);
   const { username } = useAuth();
-  const [currentTab, setCurrentTab] = useState('code_editor');
 
   useEffect(() => {
     const fetchRoom = async () => {

--- a/frontend/types/Question.ts
+++ b/frontend/types/Question.ts
@@ -35,4 +35,5 @@ export type Question = {
   topics: QuestionTopic[];
   complexity: QuestionComplexity;
   link: string;
+  solution: string;
 };


### PR DESCRIPTION
1. Non admin cannot see `Add Question`, `Delete`, `Edit` buttons, if they enter http://localhost:3000/questions/create, they will be routed back to http://localhost:3000/questions

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/05fdaa0e-a8a0-44fd-a88a-d9e830c3146a">


2.  To make a user admin, need to edit in mongoDB directly.

3.  New field for Question: `solution`

<img width="1538" alt="image" src="https://github.com/user-attachments/assets/0010e15f-0e23-489f-aa45-6be7eeb070d5">


